### PR TITLE
feat: add deprecation notification and notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Nx Console Idea Plugin
-
 ![Build](https://github.com/iguissouma/nx-console-idea-plugin/workflows/Build/badge.svg)
 [![Version](https://img.shields.io/jetbrains/plugin/v/com.github.iguissouma.nxconsole.svg)](https://plugins.jetbrains.com/plugin/15101-nx-console-idea)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/com.github.iguissouma.nxconsole.svg)](https://plugins.jetbrains.com/plugin/15101-nx-console-idea)
+
+
+> [!IMPORTANT]
+> Nx Console Idea is no longer actively maintained. Please switch to the official 'Nx Console' plugin maintained by the Nx team with the help of @iguissouma.
+> You can find it here:
+> - [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/21060-nx-console)
+> - [GitHub](https://github.com/nrwl/nx-console)
 
 <!-- Plugin description -->
 

--- a/src/main/kotlin/com/github/iguissouma/nxconsole/deprecation/NxConsolePluginReplacement.kt
+++ b/src/main/kotlin/com/github/iguissouma/nxconsole/deprecation/NxConsolePluginReplacement.kt
@@ -1,0 +1,6 @@
+package com.github.iguissouma.nxconsole.deprecation
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.ide.plugins.PluginReplacement
+
+class NxConsolePluginReplacement() : PluginReplacement("dev.nx.console") {}

--- a/src/main/kotlin/com/github/iguissouma/nxconsole/deprecation/ShowDeprecationNoticeStartupActivity.kt
+++ b/src/main/kotlin/com/github/iguissouma/nxconsole/deprecation/ShowDeprecationNoticeStartupActivity.kt
@@ -1,0 +1,42 @@
+package com.github.iguissouma.nxconsole.deprecation
+
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.notification.*
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+import com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.installAndEnable
+import com.intellij.openapi.vcs.changes.shelf.ShelveChangesManager.PostStartupActivity
+
+class ShowDeprecationNoticeStartupActivity: ProjectActivity {
+
+    override suspend fun execute(project: Project) {
+        val dontShowAgain = PropertiesComponent.getInstance(project).getBoolean("com.github.iguissouma.nxconsole.dontShowDeprecationNoticeAgain")
+
+        if(dontShowAgain) {
+            return
+        }
+
+        val notificationGroup = NotificationGroupManager.getInstance().getNotificationGroup("Nx Console")
+        notificationGroup.createNotification(
+                "Please switch to the official Nx Console plugin maintained by the Nx team.",
+                NotificationType.WARNING,
+        ).setTitle("Nx Console Idea is deprecated").addActions(listOf(
+                object : NotificationAction("Install Nx Console") {
+                    override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                        installAndEnable(project, setOf(PluginId.getId("dev.nx.console")), true, false, null ) {}
+                        notification.expire()
+                    }
+                },
+                object : NotificationAction("Don't show again") {
+                    override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                        PropertiesComponent.getInstance(project).setValue("com.github.iguissouma.nxconsole.dontShowDeprecationNoticeAgain", true)
+                        notification.expire()
+                    }
+                }
+        ) as Collection<AnAction>).notify(project)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -114,6 +114,8 @@
         <psi.referenceContributor language="JSON" implementation="com.github.iguissouma.nxconsole.references.NxProjectJsonReferenceContributor"/>
         <completion.contributor language="JSON" implementationClass="com.github.iguissouma.nxconsole.completions.NxProjetJsonCompletionContributor" order="first" />
 
+        <pluginReplacement implementation="com.github.iguissouma.nxconsole.deprecation.NxConsolePluginReplacement"/>
+        <postStartupActivity implementation="com.github.iguissouma.nxconsole.deprecation.ShowDeprecationNoticeStartupActivity"/>
 
     </extensions>
 


### PR DESCRIPTION
Adds some things: 
- a note to README to let folks know about the new plugin
- marks the official plugin as a replacement so when ppl install Nx Console, they will be prompted to uninstall Nx Console Idea
- a notification on startup about the deprecation. It will be shown whenever you open a new project unless you click on 'don't show again'
<img width="362" alt="image" src="https://github.com/iguissouma/nx-console-idea-plugin/assets/34165455/50549766-e21a-48dd-a687-68174aaa386d">
